### PR TITLE
feature/named-externals

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -229,6 +229,26 @@ const modules = {
     ]
   },
 
+  // Bundle
+  bundle: {
+    order: {
+      css: [
+        // Insert external project names here
+        '**/project-name.css',
+        '**/bower.css',
+        '**/app.css',
+        '**/*.css'
+      ],
+      js: [
+        // Insert external project names here
+        '**/project-names.js',
+        '**/bower.js',
+        '**/app.js',
+        '**/*.js'
+      ]
+    }
+  },
+
   // Critical
   critical: {
     inline: false,

--- a/gulpfile.js/modules/paths.js
+++ b/gulpfile.js/modules/paths.js
@@ -61,7 +61,9 @@ const languages = [
  */
 
 const externals = {
-  public: '../external/code/public/'
+  public: '../external/www/',
+  css: 'css/vendor/',
+  js: 'js/vendor/'
 };
 
 

--- a/gulpfile.js/tasks/bundle.js
+++ b/gulpfile.js/tasks/bundle.js
@@ -45,11 +45,7 @@ function bundleJS() {
         plugins.sourcemaps.init({loadMaps: true})
       )
     )
-    .pipe(plugins.order([
-      '**/bower.js',
-      '**/app.js',
-      '**/*.js'
-    ]))
+    .pipe(plugins.order(config.modules.order.js))
     .pipe(plugins.groupConcat({
       'main.js': src
     }))
@@ -84,11 +80,7 @@ function bundleCSS() {
         plugins.sourcemaps.init({loadMaps: true})
       )
     )
-    .pipe(plugins.order([
-      '**/bower.css',
-      '**/app.css',
-      '**/*.css'
-    ]))
+    .pipe(plugins.order(config.modules.order.css))
     .pipe(plugins.groupConcat({
       'main.css': src
     }))

--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -44,8 +44,23 @@ function clean(toClean) {
  */
 
 // CSS
-function cleanCSS() {
+function cleanCSSAll() {
   return clean(paths.base.www + paths.modules.css.root);
+}
+
+// CSS common files
+function cleanCSSCommon() {
+  return clean(paths.base.www + paths.modules.css.common);
+}
+
+// CSS modules files
+function cleanCSSModules() {
+  return clean(paths.base.www + paths.modules.css.modules);
+}
+
+// CSS vendor files
+function cleanCSSVendor() {
+  return clean(paths.base.www + paths.modules.css.common);
 }
 
 
@@ -249,7 +264,7 @@ function cleanPostProduction() {
 
 const cleanApp = gulp.series(
   gulp.parallel(
-    cleanCSS,
+    cleanCSSAll,
     cleanSprite,
     cleanJSAll,
     cleanIcons,
@@ -276,7 +291,12 @@ const cleanApp = gulp.series(
  */
 
 module.exports = {
-  css: cleanCSS,
+  css: {
+    all: cleanCSSAll,
+    common: cleanCSSCommon,
+    modules: cleanCSSModules,
+    vendor: cleanCSSVendor
+  },
   sprite: cleanSprite,
   js: {
     all: cleanJSAll,

--- a/gulpfile.js/tasks/externals.js
+++ b/gulpfile.js/tasks/externals.js
@@ -14,9 +14,12 @@
 const gulp = require('gulp');
 
 // Gulp requires
+const plugins = require('gulp-load-plugins');
 const config = require('../config');
 const paths = require('../modules/paths');
 const utils = require('../modules/utils');
+
+const packageFile = require('../../package.json');
 
 
 /**
@@ -29,6 +32,7 @@ function copyJS() {
   ], {
     base: paths.base.www
   })
+    .pipe(plugins.rename(paths.externals.js + packageFile.name + '.js'))
     .pipe(gulp.dest(paths.externals.public));
 }
 
@@ -42,6 +46,7 @@ function copyCSS() {
   ], {
     base: paths.base.www
   })
+    .pipe(plugins.rename(paths.externals.css + packageFile.name + '.css'))
     .pipe(gulp.dest(paths.externals.public));
 }
 

--- a/gulpfile.js/tasks/externals.js
+++ b/gulpfile.js/tasks/externals.js
@@ -19,6 +19,7 @@ const config = require('../config');
 const paths = require('../modules/paths');
 const utils = require('../modules/utils');
 
+// Local variables
 const packageFile = require('../../package.json');
 
 

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -256,10 +256,10 @@ function watchChanges() {
       gulp.series(
         clean.css.common,
         clean.css.modules,
-        sass.process,
+        stylus.process,
         bundle.css,
         externals.css,
-        lint.sass,
+        lint.stylus,
         utils.reload,
         notice.rebuilt
       ),

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -227,6 +227,46 @@ function watchChanges() {
     )
   );
 
+  // Externals JS
+  gulp.watch(
+    [
+      paths.base.www + paths.externals.js
+    ],
+    debounce(
+      gulp.series(
+        clean.js.common,
+        clean.js.modules,
+        js.process,
+        bundle.js,
+        externals.js,
+        lint.js,
+        utils.reload,
+        notice.rebuilt
+      ),
+      500
+    )
+  );
+
+  // Externals CSS
+  gulp.watch(
+    [
+      paths.base.www + paths.externals.css
+    ],
+    debounce(
+      gulp.series(
+        clean.css.common,
+        clean.css.modules,
+        sass.process,
+        bundle.css,
+        externals.css,
+        lint.sass,
+        utils.reload,
+        notice.rebuilt
+      ),
+      500
+    )
+  );
+
   // Images
   gulp.watch(
     [paths.base.src + paths.patterns.images.all],


### PR DESCRIPTION
Am bagat in task-ul de external un rename din `main.js`/`main.css` in `nume_proiect.js`/`nume_proiect.css`. 
Fisierul va fi pus in www-ul proiectului **frate** in folderul de css sau js in **vendor** cu numele `nume_proiect.js`. 
In caz ca se vrea sa se faca prepend la fisierul `main.js` al proiectului principal, se schimba in `config.modules.bundle.order.js` si se pune numele proiectului din care se copiaza. Ex:
```
  // Bundle
  bundle: {
    order: {
      css: [
        // Insert external project names here
        '**/project-name.css',
        '**/bower.css',
        '**/app.css',
        '**/*.css'
      ],
      js: [
        // Insert external project names here
        '**/project-names.js',
        '**/bower.js',
        '**/app.js',
        '**/*.js'
      ]
    }
  }
```
In caz ca se vrea append, `nume_proiect.js` se pune la sfarsitul array-ului cu order.

Pentru copiere din proiectul curent in altul, se schimba paths.externals.public cu path-ul catre celalalt proiect si apoi se da `gulp externals`